### PR TITLE
Fix rendering of multiple OS

### DIFF
--- a/foreman_operatingsystem.py
+++ b/foreman_operatingsystem.py
@@ -114,7 +114,7 @@ def get_resources(resource_type, resource_specs):
             for key in item:
                 search_data[key] = item[key]
         else:
-            search_data['name'] = item.get('name')
+            search_data['name'] = item
         try:
             resource = theforeman.search_resource(resource_type=resource_type, data=search_data)
             if not resource:


### PR DESCRIPTION
Maybe it's me not getting something but
with dict of operatingsystems like
```
foreman_operatingsystems:
  - name: CentOS
    family: 'Redhat'
    major: 6
    minor: 7
    architectures:
      - x86_64
    media:
      - CentOS local
    ptables:
      - vm lvm
    state: present

  - name: CentOS
    family: 'Redhat'
    major: 7
    minor: 1.1503
    architectures:
      - x86_64
    media:
      - CentOS local
    ptables:
      - vm lvm
    state: present
```
ansible fails with
```
TASK: [nosmoht.foreman | Ensure Operatingsystem] ****************************** 
failed: [foreman.infra.sbx.avp.ru] => (item={'major': 6, 'name': 'CentOS', 'family': 'Redhat', 'media': ['CentOS local'], 'ptables': ['vm lvm'], 'state': 'present', 'architectures': ['x86_64'], 'minor': 7}) => {"failed": true, "item": {"architectures": ["x86_64"], "family": "Redhat", "major": 6, "media": ["CentOS local"], "minor": 7, "name": "CentOS", "ptables": ["vm lvm"], "state": "present"}, "parsed": false}
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1444729880.11-100989970314924/foreman_operatingsystem", line 1833, in <module>
    main()
  File "/root/.ansible/tmp/ansible-tmp-1444729880.11-100989970314924/foreman_operatingsystem", line 222, in main
    changed, os = ensure()
  File "/root/.ansible/tmp/ansible-tmp-1444729880.11-100989970314924/foreman_operatingsystem", line 157, in ensure
    data['architectures'] = get_resources(resource_type='architectures', resource_specs=module.params['architectures'])
  File "/root/.ansible/tmp/ansible-tmp-1444729880.11-100989970314924/foreman_operatingsystem", line 117, in get_resources
    search_data['name'] = item.get('name')
AttributeError: 'str' object has no attribute 'get'
```
this PR fixes it

